### PR TITLE
Remove prototyping-kit git remote on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ By default, the username and password are `testing`. You MUST change this.
 #### Installing the things
 `$ npm install`
 
-#### Start the thing
-Parcel implementation: `$ npm run parcel:start`
-
-Webpack implemention: `$ npm run webpack:watch`
-
 #### Build the thing (build out the `dist` folder if you want to deploy straight away)
 Parcel implementation: `$ npm run parcel:build`
 
 Webpack implementation: `$ npm run webpack:build`
+
+#### Start the thing
+Parcel implementation: `$ npm run parcel:start`
+
+Webpack implemention: `$ npm run webpack:watch`
 
 ## Deploying to Heroku
 
@@ -64,7 +64,7 @@ $ heroku container:push web
 $ heroku container:release web
 $ heroku open
 ```
-or (depending on which implementation you're using)
+or a simplfied command (this chains the above commands together for you):
 ```
 npm run parcel:deploy
 npm run wepack:deploy

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,10 @@ then
     printf "Added files for Parcel implementation!"
     printf "\n\n"
 
+    git remote rm origin
+
+    printf "Removed Git remote"
+
 else
     printf "\n\n"
     printf "You chose Webpack!"
@@ -66,4 +70,8 @@ else
     printf "\n\n"
     printf "Added files for Webpack implementation!"
     printf "\n\n"
+
+    git remote rm origin
+
+    printf "Removed Git remote"
 fi


### PR DESCRIPTION
When someone clones this repo, the git remote persists. This can cause confusion and people could accidentally commit back to this repo